### PR TITLE
fix: typo in opencore-utils.rb

### DIFF
--- a/Formula/opencore-utils.rb
+++ b/Formula/opencore-utils.rb
@@ -19,7 +19,7 @@ class OpencoreUtils < Formula
     bin.install_symlink "#{prefix}/LegacyBoot/BootInstall_X64.tool" => "bootinstall_x64"
 
     prefix.install "Utilities/LogoutHook"
-    bin.install_symlink "#{prefix}/LogoutHook/LogoutHook.command" => "logouthook
+    bin.install_symlink "#{prefix}/LogoutHook/LogoutHook.command" => "logouthook"
 
     prefix.install "Utilities/macrecovery"
     bin.install_symlink "#{prefix}/macrecovery/macrecovery.py" => "macrecovery"


### PR DESCRIPTION
Some people failed tapping.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/22931465/108960568-147da680-76b1-11eb-820c-7837e51af1aa.png">
